### PR TITLE
Run Kong on locally provisioned K8 cluster

### DIFF
--- a/minikube/README.md
+++ b/minikube/README.md
@@ -1,52 +1,20 @@
-# [KONG][website-url] :heavy_plus_sign: [Kubernetes Deployment](http://kubernetes.io/)
+Kong can easily be provisioned to Minikube cluster using the following steps:
 
-[![Website][website-badge]][website-url]
-[![Documentation][documentation-badge]][documentation-url]
-[![Mailing List][mailing-list-badge]][mailing-list-url]
-[![Gitter Badge][gitter-badge]][gitter-url]
+1.  **Deploy Kubernetes via Minikube**
+    
+    You need [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and
+    [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+    command-line tools installed and set up to run deployment commands.
 
-[![][kong-logo]][website-url]
-
-Kong can easily be provisioned to Kubernetes cluster using the following steps:
-
-1. **Initial setup**
-  
-    Download or clone the following repo:
+    Using the `minikube` command, deploy a Kubernetes cluster.
 
     ```bash
-    $ git clone git@github.com:Mashape/kong-dist-kubernetes.git
-    $ cd kong-dist-kubernetes
-    ```
-    If you want to run Kubernetes locally, please follow the [README](/minikube) 
-    in `minikube` subfolder.
-    
-    Skip to step 3 if you have already provisioned a cluster and registered it
-    with Kubernetes.
-
-2.  **Deploy a GKE cluster**
-    
-    You need [gcloud](https://cloud.google.com/sdk/) and
-    [kubectl]https://cloud.google.com/container-engine/docs/quickstart#install_the_gcloud_command-line_interface)
-    command-line tools installed and set upto run deployment commands.
-    Also make sure your Google Cloud account has atleast two `STATIC_ADDRESSES` available.
-
-    Using the `cluster.yaml` file from this repo, deploy a
-    GKE cluster. Provide the following information before deploying:
-    
-    1. Desired cluster name
-    2. Zone in which to run the cluster
-    3. A basicauth username and password for authenticating the access to the
-       cluster
-
-    ```bash
-    $ gcloud deployment-manager deployments \ 
-        create cluster --config cluster.yaml
+    $ minikube start
     ```
 
-    By now, you have provisioned a Kubernetes managed cluster.
+    By now, you have provisioned a Kubernetes managed cluster locally.
 
-
-3. **Deploy a Kong supported database**
+2. **Deploy a Kong supported database**
   
     Before deploying Kong, you need to provision a Cassandra or PostgreSQL pod.
 
@@ -65,7 +33,7 @@ Kong can easily be provisioned to Kubernetes cluster using the following steps:
     $ kubectl create -f postgres.yaml
     ```
 
-4. **Deploy Kong**
+3. **Deploy Kong**
 
     Using the `kong_<postgres|cassandra>.yaml` file from this repo, deploy
     a Kong `Service` and a `Deployment` to the cluster created in the last step:
@@ -74,7 +42,7 @@ Kong can easily be provisioned to Kubernetes cluster using the following steps:
     $ kubectl create -f kong_<postgres|cassandra>.yaml
     ```
 
-5. **Verify your deployments**
+4. **Verify your deployments**
 
     You can now see the resources that have been deployed using `kubectl`:
 
@@ -86,15 +54,17 @@ Kong can easily be provisioned to Kubernetes cluster using the following steps:
     $ kubectl get logs <pod-name>
     ```
 
-    Once the `EXTERNAL_IP` is available for Kong Proxy and Admin services, you
+    Once the kong-admin and kong-proxy pods are started, you
     can test Kong by making the following requests:
 
     ```bash
-    $ curl <admin-ip-address>:8001
-    $ curl <proxy-ip-address>:8000
+    $ curl $(minikube service --url kong-admin)
+    $ curl $(minikube service --url kong-proxy|head -n1)
     ```
 
-6. **Using Kong**
+    It may take up to 3 minutes for all services to come up.
+
+5. **Using Kong**
 
     Quickly learn how to use Kong with the 
     [5-minute Quickstart](https://getkong.org/docs/latest/getting-started/quickstart/).

--- a/minikube/cassandra.yaml
+++ b/minikube/cassandra.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cassandra
+spec:
+  ports:
+  - name: cql
+    port: 9042
+    targetPort: 9042
+    protocol: TCP
+  selector:
+    app: cassandra
+
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: cassandra
+  # The labels will be applied automatically
+  # from the labels in the pod template, if not set
+  # labels:
+    # app: cassandra
+spec:
+  replicas: 3
+  # The selector will be applied automatically
+  # from the labels in the pod template, if not set.
+  # selector:
+      # app: cassandra
+  template:
+    metadata:
+      labels:
+        app: cassandra
+    spec:
+      containers:
+        - command:
+            - /run.sh
+          resources:
+            limits:
+              cpu: 0.5
+          env:
+            - name: MAX_HEAP_SIZE
+              value: 512M
+            - name: HEAP_NEWSIZE
+              value: 100M
+            - name: CASSANDRA_SEED_PROVIDER
+              value: "io.k8s.cassandra.KubernetesSeedProvider"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: gcr.io/google-samples/cassandra:v11
+          name: cassandra
+          ports:
+            - containerPort: 7000
+              name: intra-node
+            - containerPort: 7001
+              name: tls-intra-node
+            - containerPort: 7199
+              name: jmx
+            - containerPort: 9042
+              name: cql
+          volumeMounts:
+            - mountPath: /cassandra_data
+              name: data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/minikube/kong_cassandra.yaml
+++ b/minikube/kong_cassandra.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-proxy
+spec:
+  type: NodePort
+  ports:
+  - name: kong-proxy
+    port: 8000
+    targetPort: 8000
+    protocol: TCP
+  - name: kong-proxy-ssl
+    port: 8443
+    targetPort: 8443
+    protocol: TCP
+  selector:
+    app: kong
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-admin
+spec:
+  type: NodePort
+  ports:
+  - name: kong-admin
+    port: 8001
+    targetPort: 8001
+    protocol: TCP
+  selector:
+    app: kong
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kong-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kong-rc
+        app: kong
+    spec:
+      containers:
+      - name: kong
+        image: kong
+        env:
+          - name: KONG_DATABASE
+            value: cassandra
+          - name: KONG_CASSANDRA_CONTACT_POINTS
+            value: cassandra.default.svc.cluster.local
+          - name: KONG_CASSANDRA_KEYSPACE
+            value: kong
+          - name: KONG_CASSANDRA_REPL_FACTOR
+            value: "2"
+          - name: KONG_HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+        command: [ "/bin/sh", "-c", "KONG_CLUSTER_ADVERTISE=$(KONG_HOST_IP):7946 KONG_NGINX_DAEMON='off' kong start" ]
+        ports:
+        - name: admin
+          containerPort: 8001
+          protocol: TCP
+        - name: proxy
+          containerPort: 8000
+          protocol: TCP
+        - name: proxy-ssl
+          containerPort: 8443
+          protocol: TCP
+        - name: surf-tcp
+          containerPort: 7946
+          protocol: TCP
+        - name: surf-udp
+          containerPort: 7946
+          protocol: UDP

--- a/minikube/kong_postgres.yaml
+++ b/minikube/kong_postgres.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-proxy
+spec:
+  type: NodePort
+  ports:
+  - name: kong-proxy
+    port: 8000
+    targetPort: 8000
+    protocol: TCP
+  - name: kong-proxy-ssl
+    port: 8443
+    targetPort: 8443
+    protocol: TCP
+  selector:
+    app: kong
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-admin
+spec:
+  type: NodePort
+  ports:
+  - name: kong-admin
+    port: 8001
+    targetPort: 8001
+    protocol: TCP
+  selector:
+    app: kong
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kong-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kong-rc
+        app: kong
+    spec:
+      containers:
+      - name: kong
+        image: kong
+        env:
+          - name: KONG_PG_PASSWORD
+            value: kong
+          - name: KONG_PG_HOST
+            value: postgres.default.svc.cluster.local
+          - name: KONG_HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+        command: [ "/bin/sh", "-c", "KONG_CLUSTER_ADVERTISE=$(KONG_HOST_IP):7946 KONG_NGINX_DAEMON='off' kong start" ]
+        ports:
+        - name: admin
+          containerPort: 8001
+          protocol: TCP
+        - name: proxy
+          containerPort: 8000
+          protocol: TCP
+        - name: proxy-ssl
+          containerPort: 8443
+          protocol: TCP
+        - name: surf-tcp
+          containerPort: 7946
+          protocol: TCP
+        - name: surf-udp
+          containerPort: 7946
+          protocol: UDP

--- a/minikube/postgres.yaml
+++ b/minikube/postgres.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  ports:
+  - name: pgql
+    port: 5432
+    targetPort: 5432
+    protocol: TCP
+  selector:
+    app: postgres
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:9.4
+          env:
+            - name: POSTGRES_USER
+              value: kong
+            - name: POSTGRES_PASSWORD
+              value: kong
+            - name: POSTGRES_DB
+              value: kong
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: pg-data
+      volumes:
+        - name: pg-data
+          emptyDir: {}


### PR DESCRIPTION
Provides guide and Minikube compatible templates to run
Kong on locally provisioned K8 cluster using Minikube.

https://kubernetes.io/docs/getting-started-guides/minikube/

Note: This PR is based of PR#15