### PR TITLE
apiVersion missing from service definition

### DIFF
--- a/kong_postgres.yaml
+++ b/kong_postgres.yaml
@@ -49,6 +49,7 @@ spec:
     app: kong  
 
 ---
+apiVersion: v1
 kind: Service
 metadata:
   name: kong-admin-ssl


### PR DESCRIPTION
There's a missing key in one of the service definitions.  `kong-admin-ssl` doesn't have the `apiVersion` which makes the instruction `k create -f kong_postgres.yaml` to fail. This fixes the issue